### PR TITLE
Return option from update when using Forms from PlayPlugin

### DIFF
--- a/activate-play/src/main/scala/net/fwbrasil/activate/play/EntityForm.scala
+++ b/activate-play/src/main/scala/net/fwbrasil/activate/play/EntityForm.scala
@@ -75,19 +75,23 @@ class EntityData[T <: Entity](val data: List[(String, Any)])(
 	entityMetadata: EntityMetadata)
 		extends Serializable {
 
-	def updateEntity(id: String) = context.transactional {
-		val entity = context.byId(id).get
-		val metadatasMap = entityMetadata.propertiesMetadata.mapBy(_.name)
-		for ((property, value) <- data) {
-			val ref = entity.varNamed(property)
-			val propertyMetadata = metadatasMap(property)
-			if (propertyMetadata.isOption)
-				ref.put(value.asInstanceOf[Option[_]])
-			else
-				ref.putValue(value)
-		}
-		entity
-	}
+	def updateEntity(id: String): T = tryUpdate(id).get
+
+  def tryUpdate(id: String): Option[T] = context.transactional {
+    context.byId(id).map { entity =>
+      val metadatasMap = entityMetadata.propertiesMetadata.mapBy(_.name)
+      for ((property, value) <- data) {
+        val ref = entity.varNamed(property)
+        val propertyMetadata = metadatasMap(property)
+        if (propertyMetadata.isOption)
+          ref.put(value.asInstanceOf[Option[_]])
+        else
+          ref.putValue(value)
+      }
+      entity
+    }
+  }
+
 	def createEntity = context.transactional {
 		val entityClass = erasureOf[T]
 		val id = IdVar.generateId(entityClass)


### PR DESCRIPTION
Adds a method similar to updateEntity, but returns an Option[T] instead of T, returning None if entity is not found.
