### PR TITLE
WildcardRegexUtil.wildcardToRegex case fall-through not working

### DIFF
--- a/activate-core/src/main/scala/net/fwbrasil/activate/util/WildcardRegexUtil.scala
+++ b/activate-core/src/main/scala/net/fwbrasil/activate/util/WildcardRegexUtil.scala
@@ -11,17 +11,7 @@ object WildcardRegexUtil {
                     s.append(".*")
                 case '?' =>
                     s.append(".")
-                case '(' =>
-                case ')' =>
-                case '[' =>
-                case ']' =>
-                case '$' =>
-                case '^' =>
-                case '.' =>
-                case '{' =>
-                case '}' =>
-                case '|' =>
-                case '\\' =>
+                case '(' | ')' | '[' | ']' | '$' | '^' | '.' | '{' | '}' | '|' | '\\' =>
                     s.append("\\")
                     s.append(c)
                 case default =>


### PR DESCRIPTION
Due to the non-fallthrough of `case` statements the `wildcardToRegex` of `WildcardRegexUtil` was working incorrectly.

```
"*@example.com" --> "^.*@examplecom"
```

Code has been updated and now this resolves correctly.
