### PR TITLE
Update plugins.sbt

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,4 +4,4 @@ resolvers += Resolver.url("sbt-plugin-releases", new URL("http://scalasbt.artifa
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8")
 
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.2.0")
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.2")


### PR DESCRIPTION
Version 1.2.0 no longer seems to be online and results in an unresolved dependency. Maybe it would in general be better to leave out the eclipse and idea plugins and comment for users to include them in their global plugins.sbt file
