### PR TITLE
set the sbt version in order to guarantee a replicatable build.

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.12.3


### PR DESCRIPTION
depending on the actual used sbt.version one would need to use a different value.
