### PR TITLE
Feature postgres enhancment

### DIFF
--- a/activate-jdbc/src/main/scala/net/fwbrasil/activate/storage/relational/idiom/PostgresqlDialect.scala
+++ b/activate-jdbc/src/main/scala/net/fwbrasil/activate/storage/relational/idiom/PostgresqlDialect.scala
@@ -127,7 +127,7 @@ class postgresqlDialect(pEscape: String => String, pNormalize: String => String)
             case value: FloatStorageValue =>
                 "DOUBLE PRECISION"
             case value: DateStorageValue =>
-                "TIMESTAMP"
+                "TIMESTAMPTZ"
             case value: DoubleStorageValue =>
                 "DOUBLE PRECISION"
             case value: BigDecimalStorageValue =>


### PR DESCRIPTION
I would like to include some small changed to the underlying postgres data-types.

For one using TEXT instead of VARCHAR, because there is no difference in performance between those too, they are stored exactly the same, with VARCHAR having a upper limit, but since it is not imposed by the user it should not have one.

The second enhancement is more for my own sanity. But maybe we should provide a DateStorageValue and a DateTZStorageValue, JodaTime actually uses TZ info, but could it be that we lose it by entering it into the db? 
