### PR TITLE
Parens in SQL conditions

### DIFF
--- a/activate-core/src/main/scala/net/fwbrasil/activate/statement/StatementWhere.scala
+++ b/activate-core/src/main/scala/net/fwbrasil/activate/statement/StatementWhere.scala
@@ -75,7 +75,7 @@ case class ToUpperCase(value: StatementSelectValue) extends FunctionApply(value)
 
 case class ToLowerCase(value: StatementSelectValue) extends FunctionApply(value) {
     override def toString = s"toLowerCase($value)"
-    def entityValue = value.entityValue.asInstanceOf[StringEntityValue].value.map(_.toUpperCase)
+    def entityValue = value.entityValue.asInstanceOf[StringEntityValue].value.map(_.toLowerCase)
 }
 
 case class IsNotNull(valueA: StatementSelectValue) extends SimpleOperator {

--- a/activate-core/src/main/scala/net/fwbrasil/activate/storage/relational/idiom/QlIdiom.scala
+++ b/activate-core/src/main/scala/net/fwbrasil/activate/storage/relational/idiom/QlIdiom.scala
@@ -333,7 +333,7 @@ trait QlIdiom {
     def toSqlDml(value: Criteria)(implicit binds: MutableMap[StorageValue, String]): String =
         value match {
             case value: BooleanOperatorCriteria =>
-                toSqlDml(value.valueA) + toSqlDml(value.operator) + toSqlDml(value.valueB)
+                "(" + toSqlDml(value.valueA) + toSqlDml(value.operator) + toSqlDml(value.valueB) + ")"
             case value: SimpleOperatorCriteria =>
                 toSqlDml(value.valueA) + toSqlDml(value.operator)
             case CompositeOperatorCriteria(valueA: StatementValue, operator: Matcher, valueB: StatementValue) =>

--- a/activate-test/src/test/scala/net/fwbrasil/activate/statement/query/QuerySpecs.scala
+++ b/activate-test/src/test/scala/net/fwbrasil/activate/statement/query/QuerySpecs.scala
@@ -101,7 +101,7 @@ class QuerySpecs extends ActivateTest {
 
                         select[ActivateTestEntity].where(
                             _.entityValue isNull,
-                            _.charValue :== 'A' //, 
+                            _.charValue :== 'A' //,
                         //							_.enumerationValue isNull
                         ).headOption must beNone
                     }
@@ -181,6 +181,36 @@ class QuerySpecs extends ActivateTest {
                             (e: ActivateTestEntity) =>
                                 where((e.booleanValue isNotNull) :&& (e.stringValue isNotNull)) select (e)
                         }.size must beEqualTo(1)
+                    }
+                })
+        }
+
+        "support query with and, or, and parentheses" in {
+            activateTest(
+                (step: StepExecutor) => {
+                    import step.ctx._
+                    step {
+                        newFullActivateTestEntity
+                        newEmptyActivateTestEntity
+                    }
+                    step {
+                        query {
+                            // E.g. SELECT * from XYZ where a = true && (a = true OR a = false)
+                            // Equivalent to SELECT * from XYZ where a = true
+                            (e: ActivateTestEntity) => where(
+                                (e.booleanValue :== true) :&&
+                                ((e.booleanValue :== true) :|| (e.booleanValue :== false))
+                            ) select (e)
+                        }.size must beEqualTo(1)
+
+                        query {
+                            // E.g. SELECT * from XYZ where a = true && a = true OR a = false
+                            // Equivalent to SELECT * from XYZ where a = true OR a = false
+                            (e: ActivateTestEntity) => where(
+                                (e.booleanValue :== true) :&&
+                                (e.booleanValue :== true) :|| (e.booleanValue :== false)
+                            ) select (e)
+                        }.size must beEqualTo(3)
                     }
                 })
         }


### PR DESCRIPTION
It seems like Activate ignores parentheses in the `where` part of the query. This doesn't allow writing more elaborate conditional queries.
