### PR TITLE
Update to Play 2.3.2

### DIFF
--- a/project/ActivateBuild.scala
+++ b/project/ActivateBuild.scala
@@ -188,8 +188,8 @@ object ActivateBuild extends Build {
             )
         )
 
-    val play = "com.typesafe.play" %% "play" % "2.2.1"
-    val playTest = "com.typesafe.play" %% "play-test" % "2.2.1"
+    val play = "com.typesafe.play" %% "play" % "2.3.2"
+    val playTest = "com.typesafe.play" %% "play-test" % "2.3.2"
 
     lazy val activatePlay =
         Project(


### PR DESCRIPTION
Play's Mapping class 'unbind' method now doesn't validate anymore. 

Activate's EntityMapping now follows the same signature.
