### PR TITLE
Cross build for Scala 2.10 and Scala 2.11

### DIFF
--- a/activate-core/src/main/scala/net/fwbrasil/activate/util/Reflection.scala
+++ b/activate-core/src/main/scala/net/fwbrasil/activate/util/Reflection.scala
@@ -7,6 +7,7 @@ import java.lang.reflect.Method
 import java.lang.reflect.Modifier
 import java.util.Date
 
+import scala.collection.JavaConversions.asScalaSet
 import scala.collection.concurrent.TrieMap
 import scala.collection.mutable.{ HashMap => MutableHashMap }
 import scala.language.existentials
@@ -121,8 +122,9 @@ object Reflection {
     def getAllImplementorsNames(classpathHints: List[Any], interfaceClass: Class[_]) = {
         val hints = reflectionsHints(classpathHints ++ List(interfaceClass))
         val reflections = reflectionsFor(hints)
-        val subtypes = reflections.getStore.getSubTypesOf(interfaceClass.getName).toArray
-        Set(subtypes: _*).asInstanceOf[Set[String]]
+        val subtypes = reflections.getSubTypesOf(interfaceClass)
+        val names = for (subtype <- subtypes) yield { subtype.getCanonicalName }
+        names.toSet
     }
 
     import language.existentials

--- a/activate-core/src/main/scala/net/fwbrasil/activate/util/Reflection.scala
+++ b/activate-core/src/main/scala/net/fwbrasil/activate/util/Reflection.scala
@@ -7,7 +7,7 @@ import java.lang.reflect.Method
 import java.lang.reflect.Modifier
 import java.util.Date
 
-import scala.collection.JavaConversions.asScalaSet
+import scala.collection.JavaConversions.iterableAsScalaIterable
 import scala.collection.concurrent.TrieMap
 import scala.collection.mutable.{ HashMap => MutableHashMap }
 import scala.language.existentials
@@ -16,6 +16,7 @@ import scala.language.implicitConversions
 import org.joda.time.base.AbstractInstant
 import org.objenesis.ObjenesisStd
 import org.reflections.Reflections
+import org.reflections.scanners.SubTypesScanner
 
 import net.fwbrasil.activate.entity.BaseEntity
 
@@ -121,10 +122,9 @@ object Reflection {
 
     def getAllImplementorsNames(classpathHints: List[Any], interfaceClass: Class[_]) = {
         val hints = reflectionsHints(classpathHints ++ List(interfaceClass))
-        val reflections = reflectionsFor(hints)
-        val subtypes = reflections.getSubTypesOf(interfaceClass)
-        val names = for (subtype <- subtypes) yield { subtype.getCanonicalName }
-        names.toSet
+        val store = reflectionsFor(hints).getStore
+        val subtypes = store.getAll(classOf[SubTypesScanner].getSimpleName, interfaceClass.getName)
+        subtypes.toSet
     }
 
     import language.existentials

--- a/activate-mongo-async/src/main/scala/net/fwbrasil/activate/storage/mongo/async/AsyncMongoStorage.scala
+++ b/activate-mongo-async/src/main/scala/net/fwbrasil/activate/storage/mongo/async/AsyncMongoStorage.scala
@@ -14,8 +14,7 @@ import com.mongodb.BasicDBObject
 import net.fwbrasil.activate.storage.mongo.mongoIdiom
 import reactivemongo.bson._
 import reactivemongo.api._
-import reactivemongo.api.collections.default._
-import reactivemongo.api.collections.default.BSONGenericHandlers._
+import reactivemongo.api.collections.bson._
 import scala.concurrent.Future
 import net.fwbrasil.activate.storage.TransactionHandle
 import net.fwbrasil.activate.statement.mass.MassModificationStatement
@@ -23,7 +22,6 @@ import scala.concurrent.ExecutionContext
 import net.fwbrasil.activate.statement.mass.MassUpdateStatement
 import net.fwbrasil.activate.statement.From
 import net.fwbrasil.activate.statement.mass.MassDeleteStatement
-import play.api.libs.iteratee.Enumerator
 import net.fwbrasil.activate.storage.marshalling.ModifyStorageAction
 import net.fwbrasil.activate.storage.marshalling.StorageRenameTable
 import net.fwbrasil.activate.storage.marshalling.StorageRemoveTable
@@ -52,6 +50,7 @@ import net.fwbrasil.activate.ActivateContext
 import net.fwbrasil.activate.storage.StorageFactory
 import net.fwbrasil.activate.storage.marshalling.StorageModifyColumnType
 import net.fwbrasil.activate.util.Reflection._
+import scala.collection.immutable.Stream
 
 trait AsyncMongoStorage extends MarshalStorage[DefaultDB] with DelayedInit {
 
@@ -255,9 +254,8 @@ trait AsyncMongoStorage extends MarshalStorage[DefaultDB] with DelayedInit {
         Future(mongoIdiom.toInsertMap(insertList)).flatMap { insertMap =>
             insertMap.keys.toList.foldLeft(Future()) { (future, entityClass) =>
                 future.flatMap { _ =>
-                    val inserts = insertMap(entityClass).toList.map(dbObject(_))
-                    val enumerator = Enumerator(inserts: _*)
-                    coll(entityClass).bulkInsert(enumerator).map { _ => }
+                    val inserts = insertMap(entityClass).toStream.map(dbObject(_))
+                    coll(entityClass).bulkInsert(inserts, true).map { _ => }
                 }
             }
         }

--- a/activate-spray-json/src/main/scala/net/fwbrasil/activate/json/spray/SprayJsonContext.scala
+++ b/activate-spray-json/src/main/scala/net/fwbrasil/activate/json/spray/SprayJsonContext.scala
@@ -162,11 +162,11 @@ trait SprayJsonContext extends JsonContext[JsObject] {
                 jsValue[Enumeration#Value](value.asInstanceOf[EnumerationEntityValue[Enumeration#Value]], e => JsString(e.toString))
             case value: ListEntityValue[_] =>
                 value.value.map(list =>
-                    JsArray(list.map(e => toJsValue(value.valueEntityValue(e), depth))))
+                    JsArray(list.map(e => toJsValue(value.valueEntityValue(e), depth)).toVector))
                     .getOrElse(JsNull)
             case value: LazyListEntityValue[_] =>
                 value.value.map(list =>
-                    JsArray(list.ids.map(id => toJsValue(entityIdTval(value.entityClass)(Some(id)), depth, seenEntities))))
+                    JsArray(list.ids.map(id => toJsValue(entityIdTval(value.entityClass)(Some(id)), depth, seenEntities)).toVector))
                     .getOrElse(JsNull)
             case value: SerializableEntityValue[_] =>
                 value.value.map(v =>

--- a/activate-test/src/test/scala/net/fwbrasil/activate/ActivateTestContext.scala
+++ b/activate-test/src/test/scala/net/fwbrasil/activate/ActivateTestContext.scala
@@ -98,9 +98,8 @@ abstract class ActivateTestMigration(
 
         table[ctx.EntityByIntValue]
             .addIndex(
-                columnName = "key",
                 indexName = "IDX_KEY",
-                unique = true)
+                unique = true)("key")
             .ifNotExists
     }
 }

--- a/activate-test/src/test/scala/net/fwbrasil/activate/json/spray/SprayJsonSpecs.scala
+++ b/activate-test/src/test/scala/net/fwbrasil/activate/json/spray/SprayJsonSpecs.scala
@@ -207,9 +207,9 @@ class SprayJsonSpecs extends ActivateTest {
                         val depth0 =
                             s"""{"name":"Foo","singleTerms":["Foo","Bar"],"description":null,"subdomain":null,"id":"${entity.id}","boundingBoxes":["${entity.boundingBoxes.onlyOne.id}"],"compoundTerms":["foo bar"],"internalId":null}"""
                         val depth1 =
-                            s"""{"name":"Foo","singleTerms":["Foo","Bar"],"description":null,"subdomain":null,"id":"${entity.id}","boundingBoxes":[{"id":"${entity.boundingBoxes.onlyOne.id}","neCorner":"${entity.boundingBoxes.onlyOne.neCorner.id}","swCorner":"${entity.boundingBoxes.onlyOne.swCorner.id}"}],"compoundTerms":["foo bar"],"internalId":null}"""
+                            s"""{"name":"Foo","singleTerms":["Foo","Bar"],"description":null,"subdomain":null,"id":"${entity.id}","boundingBoxes":[{"neCorner":"${entity.boundingBoxes.onlyOne.neCorner.id}","swCorner":"${entity.boundingBoxes.onlyOne.swCorner.id}","id":"${entity.boundingBoxes.onlyOne.id}"}],"compoundTerms":["foo bar"],"internalId":null}"""
                         val depth2 =
-                            s"""{"name":"Foo","singleTerms":["Foo","Bar"],"description":null,"subdomain":null,"id":"${entity.id}","boundingBoxes":[{"id":"${entity.boundingBoxes.onlyOne.id}","neCorner":{"id":"${entity.boundingBoxes.onlyOne.neCorner.id}","longitude":-81.44999694824219,"latitude":30.3700008392334},"swCorner":{"id":"${entity.boundingBoxes.onlyOne.swCorner.id}","longitude":-81.75,"latitude":30.200000762939453}}],"compoundTerms":["foo bar"],"internalId":null}"""
+                            s"""{"name":"Foo","singleTerms":["Foo","Bar"],"description":null,"subdomain":null,"id":"${entity.id}","boundingBoxes":[{"neCorner":{"latitude":30.3700008392334,"id":"${entity.boundingBoxes.onlyOne.neCorner.id}","longitude":-81.44999694824219},"swCorner":{"latitude":30.200000762939453,"id":"${entity.boundingBoxes.onlyOne.swCorner.id}","longitude":-81.75},"id":"${entity.boundingBoxes.onlyOne.id}"}],"compoundTerms":["foo bar"],"internalId":null}"""
                         entity.toJsonString == depth0
                         entity.toJsonString(depth = 0) === depth0
                         entity.toJsonString(depth = 1) === depth1
@@ -242,8 +242,8 @@ class SprayJsonSpecs extends ActivateTest {
                             employee2.supervisor = Some(employee1)
                         }
                         step {
-                            val depth0 = s"""{"id":"$id1","supervisor":"$id2","name":"test1"}"""
-                            val depth1 = s"""{"id":"$id1","supervisor":{"id":"$id2","supervisor":"$id1","name":"test2"},"name":"test1"}"""
+                            val depth0 = s"""{"name":"test1","id":"$id1","supervisor":"$id2"}"""
+                            val depth1 = s"""{"name":"test1","id":"$id1","supervisor":{"name":"test2","id":"$id2","supervisor":"$id1"}}"""
                             employee1.toJsonString === depth0
                             employee1.toJsonString(depth = 0) === depth0
                             employee1.toJsonString(depth = 1) === depth1

--- a/project/ActivateBuild.scala
+++ b/project/ActivateBuild.scala
@@ -5,24 +5,24 @@ object ActivateBuild extends Build {
 
     /* Core dependencies */
     val javassist = "org.javassist" % "javassist" % "3.18.2-GA"
-    val radonStm = "net.fwbrasil" %% "radon-stm" % "1.7"
-    val smirror = "net.fwbrasil" %% "smirror" % "0.9"
-    val guava = "com.google.guava" % "guava" % "16.0"
+    val radonStm = "net.fwbrasil" %% "radon-stm" % "1.7.1"
+    val smirror = "net.fwbrasil" %% "smirror" % "0.9.1"
+    val guava = "com.google.guava" % "guava" % "18.0"
     val objenesis = "org.objenesis" % "objenesis" % "2.1"
     val jug = "com.fasterxml.uuid" % "java-uuid-generator" % "3.1.3"
-    val reflections = "org.reflections" % "reflections" % "0.9.8" exclude ("javassist", "javassist") exclude ("dom4j", "dom4j")
+    val reflections = "org.reflections" % "reflections" % "0.9.9" exclude ("javassist", "javassist") exclude ("dom4j", "dom4j") exclude ("com.google.guava", "guava")
     val grizzled = "org.clapper" %% "grizzled-slf4j" % "1.0.2"
-    val logbackClassic = "ch.qos.logback" % "logback-classic" % "1.1.0"
-    val jodaTime = "joda-time" % "joda-time" % "2.3"
-    val jodaConvert = "org.joda" % "joda-convert" % "1.6"
-    val blueprintsCore = "com.tinkerpop.blueprints" % "blueprints-core" % "2.4.0"
-    val blueprintsNeo4j = "com.tinkerpop.blueprints" % "blueprints-neo4j-graph" % "2.4.0"
-    val gremlin = "com.tinkerpop.gremlin" % "gremlin-java" % "2.4.0"
-    val xstream = "com.thoughtworks.xstream" % "xstream" % "1.4.6" exclude ("xpp3", "xpp3_min")
-    val jettison = "org.codehaus.jettison" % "jettison" % "1.3.4"
-    val findBugs = "com.google.code.findbugs" % "jsr305" % "2.0.1"
-    val kryo = "com.esotericsoftware.kryo" % "kryo" % "2.23.0"
-    val cassandraDriver = "com.datastax.cassandra" % "cassandra-driver-core" % "1.0.5"
+    val logbackClassic = "ch.qos.logback" % "logback-classic" % "1.1.2"
+    val jodaTime = "joda-time" % "joda-time" % "2.5"
+    val jodaConvert = "org.joda" % "joda-convert" % "1.7"
+    val blueprintsCore = "com.tinkerpop.blueprints" % "blueprints-core" % "2.6.0"
+    val blueprintsNeo4j = "com.tinkerpop.blueprints" % "blueprints-neo4j-graph" % "2.6.0"
+    val gremlin = "com.tinkerpop.gremlin" % "gremlin-java" % "2.6.0"
+    val xstream = "com.thoughtworks.xstream" % "xstream" % "1.4.7" exclude ("xpp3", "xpp3_min")
+    val jettison = "org.codehaus.jettison" % "jettison" % "1.3.6"
+    val findBugs = "com.google.code.findbugs" % "jsr305" % "3.0.0"
+    val kryo = "com.esotericsoftware.kryo" % "kryo" % "2.24.0"
+    val cassandraDriver = "com.datastax.cassandra" % "cassandra-driver-core" % "2.1.2"
 
     /* Prevayler */
     val prevaylerCore = "org.prevayler" % "prevayler-core" % "2.6"
@@ -33,19 +33,19 @@ object ActivateBuild extends Build {
     Install oracle in your local repo
   */
     val objbd6 = "com.oracle" % "ojdbc6" % "11.2.0"
-    val mysql = "mysql" % "mysql-connector-java" % "5.1.28"
-    val postgresql = "org.postgresql" % "postgresql" % "9.3-1100-jdbc4"
-    val hirakiCP = "com.zaxxer" % "HikariCP" % "1.3.8"
-    val h2 = "com.h2database" % "h2" % "1.3.175"
-    val derby = "org.apache.derby" % "derby" % "10.10.1.1"
-    val hqsqldb = "org.hsqldb" % "hsqldb" % "2.3.1"
+    val mysql = "mysql" % "mysql-connector-java" % "5.1.34"
+    val postgresql = "org.postgresql" % "postgresql" % "9.3-1102-jdbc41"
+    val hirakiCP = "com.zaxxer" % "HikariCP" % "2.2.2"
+    val h2 = "com.h2database" % "h2" % "1.4.182"
+    val derby = "org.apache.derby" % "derby" % "10.11.1.1"
+    val hqsqldb = "org.hsqldb" % "hsqldb" % "2.3.2"
     val db2jcc = "com.ibm.db2.jcc" % "db2jcc4" % "10.1"
     val jtds = "net.sourceforge.jtds" % "jtds" % "1.3.1"
 
     val gfork = "org.gfork" % "gfork" % "0.11"
 
     /* Mongo */
-    val mongoDriver = "org.mongodb" % "mongo-java-driver" % "2.11.4"
+    val mongoDriver = "org.mongodb" % "mongo-java-driver" % "2.12.4"
 
     lazy val activate =
         Project(
@@ -113,7 +113,7 @@ object ActivateBuild extends Build {
         )
 
     val slick = "com.typesafe.slick" %% "slick" % "2.1.0"
-    val scalaCompiler = "org.scala-lang" % "scala-compiler" % "2.11.2"
+    def scalaCompiler(version: String) = "org.scala-lang" % "scala-compiler" % version
 
     lazy val activateSlick =
         Project(
@@ -121,8 +121,8 @@ object ActivateBuild extends Build {
             base = file("activate-slick"),
             dependencies = Seq(activateCore, activateJdbc),
             settings = commonSettings ++ Seq(
-                libraryDependencies ++=
-                    Seq(scalaCompiler, slick)
+                // libraryDependencies ++= Seq(scalaCompiler, slick)
+                libraryDependencies <++= (scalaVersion) { v: String => Seq(scalaCompiler(v), slick) }
             )
         )
 
@@ -151,7 +151,7 @@ object ActivateBuild extends Build {
             )
         )
 
-    val reactivemongo = "org.reactivemongo" %% "reactivemongo" % "0.10.5.akka23-SNAPSHOT"
+    val reactivemongo = "org.reactivemongo" %% "reactivemongo" % "0.11.0-SNAPSHOT"
 
     lazy val activateMongoAsync =
         Project(
@@ -175,8 +175,8 @@ object ActivateBuild extends Build {
             )
         )
 
-    val play = "com.typesafe.play" %% "play" % "2.3.2"
-    val playTest = "com.typesafe.play" %% "play-test" % "2.3.2"
+    val play = "com.typesafe.play" %% "play" % "2.3.6"
+    val playTest = "com.typesafe.play" %% "play-test" % "2.3.6"
 
     lazy val activatePlay =
         Project(
@@ -202,7 +202,7 @@ object ActivateBuild extends Build {
             )
         )
 
-    val sprayJson = "io.spray" %% "spray-json" % "1.2.6"
+    val sprayJson = "io.spray" %% "spray-json" % "1.3.1"
 
     lazy val activateSprayJson =
         Project(
@@ -216,10 +216,10 @@ object ActivateBuild extends Build {
         )
 
     val jackson = Seq(
-        "com.fasterxml.jackson.core" % "jackson-core" % "2.3.1",
-        "com.fasterxml.jackson.core" % "jackson-annotations" % "2.3.1",
-        "com.fasterxml.jackson.core" % "jackson-databind" % "2.3.1",
-        "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.4.2")
+        "com.fasterxml.jackson.core" % "jackson-core" % "2.4.3",
+        "com.fasterxml.jackson.core" % "jackson-annotations" % "2.4.3",
+        "com.fasterxml.jackson.core" % "jackson-databind" % "2.4.3",
+        "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.4.3")
 
     lazy val activateJacksonJson =
         Project(
@@ -227,13 +227,14 @@ object ActivateBuild extends Build {
             base = file("activate-jackson"),
             dependencies = Seq(activateCore, activateJdbc),
             settings = commonSettings ++ Seq(
-                libraryDependencies ++=
-                    Seq(postgresql, scalaCompiler) ++ jackson
+                // libraryDependencies ++= Seq(postgresql, scalaCompiler) ++ jackson
+                libraryDependencies <++= (scalaVersion) { v: String => Seq(scalaCompiler(v), postgresql) ++ jackson }
             )
         )
 
     val junit = "junit" % "junit" % "4.11"
-    val specs2 = "org.specs2" %% "specs2" % "2.4.2"
+    val specs2 = "org.specs2" %% "specs2" % "2.4.9"
+    def scalaActors(version: String) = "org.scala-lang" % "scala-actors" % version
 
     lazy val activateTest =
         Project(id = "activate-test",
@@ -242,9 +243,9 @@ object ActivateBuild extends Build {
                 activateMongo % "test", activateGraph % "test", activateSprayJson % "test", activateJacksonJson % "test", activateJdbcAsync % "test",
                 activateSlick % "test", activateMongoAsync % "test", activatePrevalent % "test", activateCassandraAsync % "test", activateLift % "test"),
             settings = commonSettings ++ Seq(
-                libraryDependencies ++=
+                libraryDependencies <++= (scalaVersion) { v: String =>
                     Seq(junit % "test", specs2 % "test", mysql % "test", objbd6 % "test", postgresql % "test", db2jcc % "test",
-                        h2 % "test", derby % "test", hqsqldb % "test", gfork % "test", blueprintsNeo4j % "test", jtds % "test"),
+                        h2 % "test", derby % "test", hqsqldb % "test", gfork % "test", blueprintsNeo4j % "test", jtds % "test", scalaActors(v) % "test") },
                 scalacOptions ++= Seq("-Xcheckinit")
             )
         )
@@ -253,7 +254,8 @@ object ActivateBuild extends Build {
     val customResolvers = Seq(
         "Maven" at "http://repo1.maven.org/maven2/",
         "Typesafe" at "http://repo.typesafe.com/typesafe/releases",
-        "Local Maven Repository" at "file://" + Path.userHome + "/.m2/repository",
+        "Local Maven Repository" at "" + Path.userHome.asFile.toURI.toURL + "/.m2/repository",
+        "Scalaz Bintray Repo" at "http://dl.bintray.com/scalaz/releases",
         "fwbrasil.net" at "http://fwbrasil.net/maven/",
         "spray" at "http://repo.spray.io/",
         "Sonatype OSS Releases" at "http://oss.sonatype.org/content/repositories/releases/",
@@ -264,12 +266,14 @@ object ActivateBuild extends Build {
     def commonSettings =
         Defaults.defaultSettings ++ Seq(
             organization := "net.fwbrasil",
-            version := "1.7",
-            scalaVersion := "2.11.2",
+            version := "1.7.1",
+            scalaVersion := "2.11.4",
+            crossScalaVersions := Seq("2.10.4","2.11.4"),
             javacOptions ++= Seq("-source", "1.7", "-target", "1.7"),
             publishMavenStyle := true,
-            // publishTo := Some(Resolver.file("file",  new File(Path.userHome.absolutePath+"/.m2/repository"))), 
+            publishTo := Some(Resolver.file("file",  file(Path.userHome.absolutePath+"/.m2/repository"))), 
             // publishTo := Option(Resolver.ssh("fwbrasil.net repo", "fwbrasil.net", 8080) as("maven") withPermissions("0644")),
+            /*
             publishTo <<= version { v: String =>
                 val nexus = "https://oss.sonatype.org/"
                 val fwbrasil = "http://fwbrasil.net/maven/"
@@ -278,6 +282,7 @@ object ActivateBuild extends Build {
                 else
                     Some("releases" at nexus + "service/local/staging/deploy/maven2")
             },
+            // */
             resolvers ++= customResolvers,
             publishMavenStyle := true,
             publishArtifact in Test := false,

--- a/project/ActivateBuild.scala
+++ b/project/ActivateBuild.scala
@@ -257,7 +257,6 @@ object ActivateBuild extends Build {
         "Local Maven Repository" at "" + Path.userHome.asFile.toURI.toURL + "/.m2/repository",
         "Scalaz Bintray Repo" at "http://dl.bintray.com/scalaz/releases",
         "fwbrasil.net" at "http://fwbrasil.net/maven/",
-        "spray" at "http://repo.spray.io/",
         "Sonatype OSS Releases" at "http://oss.sonatype.org/content/repositories/releases/",
         "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/",
         "Alfesco" at "https://maven.alfresco.com/nexus/content/groups/public/"
@@ -271,7 +270,7 @@ object ActivateBuild extends Build {
             crossScalaVersions := Seq("2.10.4","2.11.4"),
             javacOptions ++= Seq("-source", "1.7", "-target", "1.7"),
             publishMavenStyle := true,
-            publishTo := Some(Resolver.file("file",  file(Path.userHome.absolutePath+"/.m2/repository"))), 
+            // publishTo := Some(Resolver.file("file",  file(Path.userHome.absolutePath+"/.m2/repository"))), 
             // publishTo := Option(Resolver.ssh("fwbrasil.net repo", "fwbrasil.net", 8080) as("maven") withPermissions("0644")),
             /*
             publishTo <<= version { v: String =>

--- a/project/ActivateBuild.scala
+++ b/project/ActivateBuild.scala
@@ -35,7 +35,6 @@ object ActivateBuild extends Build {
     val objbd6 = "com.oracle" % "ojdbc6" % "11.2.0"
     val mysql = "mysql" % "mysql-connector-java" % "5.1.34"
     val postgresql = "org.postgresql" % "postgresql" % "9.3-1102-jdbc41"
-    val hirakiCP = "com.zaxxer" % "HikariCP" % "2.2.2"
     val h2 = "com.h2database" % "h2" % "1.4.182"
     val derby = "org.apache.derby" % "derby" % "10.11.1.1"
     val hqsqldb = "org.hsqldb" % "hsqldb" % "2.3.2"
@@ -101,6 +100,9 @@ object ActivateBuild extends Build {
             )
         )
 
+    val hirakiCP = "com.zaxxer" % "HikariCP" % "2.2.2"
+    val metrics = "com.codahale.metrics" % "metrics-core" % "3.0.2"
+
     lazy val activateJdbc =
         Project(
             id = "activate-jdbc",
@@ -108,7 +110,7 @@ object ActivateBuild extends Build {
             dependencies = Seq(activateCore),
             settings = commonSettings ++ Seq(
                 libraryDependencies ++=
-                    Seq(hirakiCP)
+                    Seq(hirakiCP, metrics)
             )
         )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,9 @@
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.2.0")
+addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.5.0")
 
-resolvers += Resolver.url("sbt-plugin-releases", new URL("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases/"))(Resolver.ivyStylePatterns)
+//resolvers += Resolver.url("sbt-plugin-releases", new URL("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases/"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.2")
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0")
+
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.1.6")


### PR DESCRIPTION
I did correct some tests that were failing due to different order of properties in JSON, after I updated the dependencies.

However the 84 failing tests (using the _"memory turn"_) are in an illegal state which I could not understand, as per following trace:

```
[info] Activate should
[info] ! provide direct access to the storage
[error]    IllegalStateException: :
[error] There should be one and only one context that accepts class net.fwbrasil.activate.migration.StorageVersion.
[error] Maybe the context isn't initialized or you must override the contextEntities val on your context.
[error] Important: The context definition must be declared in a base package of the entities packages.
[error] Example: com.app.myContext for com.app.model.MyEntity.
[error] Found contexts: List(ActivateContext: memoryContext, ActivateContext: readValidationContext)  (RichList.scala:41)
[error] net.fwbrasil.activate.util.RichList.onlyOne(RichList.scala:41)
```

As for the case of the whole  `Reflection` file to be marked as changed only the following method (at line 123) has really been changed:

```
def getAllImplementorsNames(classpathHints: List[Any], interfaceClass: Class[_]) = {
  val hints = reflectionsHints(classpathHints ++ List(interfaceClass))
  val store = reflectionsFor(hints).getStore
  val subtypes = store.getAll(classOf[SubTypesScanner].getSimpleName, interfaceClass.getName)
  subtypes.toSet
}
```
