### PR TITLE
Adding javax.inject and @Inject annotation to the plugin

### DIFF
--- a/activate-play/src/main/scala/net/fwbrasil/activate/play/ActivatePlayPlugin.scala
+++ b/activate-play/src/main/scala/net/fwbrasil/activate/play/ActivatePlayPlugin.scala
@@ -1,5 +1,6 @@
 package net.fwbrasil.activate.play
 
+import javax.inject.Inject
 import scala.collection.mutable.{ Map => MutableMap }
 import net.fwbrasil.activate.migration.Migration
 import net.fwbrasil.activate.ActivateContext
@@ -12,7 +13,7 @@ import net.fwbrasil.activate.entity.EntityMetadata
 import net.fwbrasil.activate.util.Reflection
 import play.Play
 
-class ActivatePlayPlugin(app: play.Application) extends Plugin {
+class ActivatePlayPlugin @Inject() (app: play.Application) extends Plugin {
 
     override def onStart = 
         ActivateContext.setClassLoader(Play.application.classloader)

--- a/project/ActivateBuild.scala
+++ b/project/ActivateBuild.scala
@@ -175,8 +175,11 @@ object ActivateBuild extends Build {
             )
         )
 
-    val play = "com.typesafe.play" %% "play" % "2.3.2"
-    val playTest = "com.typesafe.play" %% "play-test" % "2.3.2"
+    val playVersion = "2.4.3"
+
+    val play = "com.typesafe.play" %% "play" % playVersion
+    val playTest = "com.typesafe.play" %% "play-test" % playVersion
+    val inject = "javax.inject" % "javax.inject" % "1"
 
     lazy val activatePlay =
         Project(
@@ -185,7 +188,7 @@ object ActivateBuild extends Build {
             dependencies = Seq(activateCore, activateTest, activateJdbc),
             settings = commonSettings ++ Seq(
                 libraryDependencies ++=
-                    Seq(play, playTest % "provided", specs2 % "provided")
+                    Seq(play, playTest % "provided", specs2 % "provided", inject)
             )
         )
 


### PR DESCRIPTION
Hi

I found out it's rather easy to provide compatibility to play 2.4.x - Just add @Inject() to ActivatePlayPlugin's constructor.

I also have a fork of the demo-project, that I upgraded to play 2.4.3 [here](https://github.com/timo-schmid/activate-example-play/tree/play-2.4). However, the integration-test does not work, thus I won't create a PR for that just yet.

Thanks for considering a merge!

Cheers!
